### PR TITLE
Apply Apple UI theme

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -76,7 +76,7 @@ const handleMenuClick = (item) => {
 html, body {
   height: 100%;
   overflow-x: hidden;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--apple-font-family);
   background: #f5f5f5;
 }
 
@@ -159,12 +159,12 @@ html, body {
 }
 
 .nav-item.active .nav-icon {
-  color: #007AFF;
+  color: var(--apple-blue);
   transform: scale(1.1);
 }
 
 .nav-item.active .nav-label {
-  color: #007AFF;
+  color: var(--apple-blue);
   font-weight: 600;
 }
 
@@ -190,7 +190,7 @@ html, body {
 }
 
 .el-button--primary {
-  background: #007AFF;
+  background: var(--apple-blue);
   color: #ffffff;
 }
 

--- a/frontend/src/components/ScanVehicle.vue
+++ b/frontend/src/components/ScanVehicle.vue
@@ -98,15 +98,15 @@
       <h3>使用提示</h3>
       <div class="tips-list">
         <div class="tip-item">
-          <el-icon color="#007AFF"><Aim /></el-icon>
+          <el-icon color="var(--apple-blue)"><Aim /></el-icon>
           <span>确保车牌清晰可见，光线充足</span>
         </div>
         <div class="tip-item">
-          <el-icon color="#007AFF"><Picture /></el-icon>
+          <el-icon color="var(--apple-blue)"><Picture /></el-icon>
           <span>尽量从正面角度拍摄</span>
         </div>
         <div class="tip-item">
-          <el-icon color="#007AFF"><Lightning /></el-icon>
+          <el-icon color="var(--apple-blue)"><Lightning /></el-icon>
           <span>AI智能识别，快速准确</span>
         </div>
       </div>
@@ -461,7 +461,7 @@ const viewVehicleRecords = async () => {
 }
 
 .scan-header {
-  background: linear-gradient(135deg, #007AFF, #0056CC);
+  background: linear-gradient(135deg, var(--apple-blue), #0056CC);
   color: white;
   padding: 24px 20px;
   text-align: center;
@@ -505,7 +505,7 @@ const viewVehicleRecords = async () => {
 .camera-button:active,
 .gallery-button:active {
   transform: scale(0.98);
-  border-color: #007AFF;
+  border-color: var(--apple-blue);
 }
 
 .camera-icon,
@@ -513,7 +513,7 @@ const viewVehicleRecords = async () => {
   width: 80px;
   height: 80px;
   border-radius: 20px;
-  background: linear-gradient(135deg, #007AFF, #0056CC);
+  background: linear-gradient(135deg, var(--apple-blue), #0056CC);
   color: white;
   display: flex;
   align-items: center;
@@ -561,11 +561,11 @@ const viewVehicleRecords = async () => {
 }
 
 .upload-content:hover {
-  border-color: #007AFF;
+  border-color: var(--apple-blue);
 }
 
 .upload-content .el-icon {
-  color: #007AFF;
+  color: var(--apple-blue);
   margin-bottom: 16px;
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,5 +1,8 @@
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  --apple-blue: #007AFF;
+  --el-color-primary: var(--apple-blue);
+  --apple-font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  font-family: var(--apple-font-family);
   line-height: 1.5;
   font-weight: 400;
 
@@ -156,7 +159,7 @@ button:focus-visible {
 }
 
 .el-button--primary {
-  background: linear-gradient(135deg, #007AFF, #0056CC);
+  background: linear-gradient(135deg, var(--apple-blue), #0056CC);
   border: none;
 }
 
@@ -172,16 +175,16 @@ button:focus-visible {
 }
 
 .el-input__wrapper:hover {
-  border-color: #007AFF;
+  border-color: var(--apple-blue);
 }
 
 .el-input__wrapper.is-focus {
-  border-color: #007AFF;
+  border-color: var(--apple-blue);
   box-shadow: 0 0 0 2px rgba(0, 122, 255, 0.1);
 }
 
 .el-select .el-input.is-focus .el-input__wrapper {
-  border-color: #007AFF;
+  border-color: var(--apple-blue);
   box-shadow: 0 0 0 2px rgba(0, 122, 255, 0.1);
 }
 
@@ -233,7 +236,7 @@ button:focus-visible {
 
 .el-dropdown-menu__item:hover {
   background: #f5f5f5;
-  color: #007AFF;
+  color: var(--apple-blue);
 }
 
 .el-loading-mask {
@@ -351,7 +354,7 @@ button:focus-visible {
 }
 
 .nav-item.active .nav-icon {
-  color: #007AFF;
+  color: var(--apple-blue);
 }
 
 .nav-label {
@@ -362,7 +365,7 @@ button:focus-visible {
 }
 
 .nav-item.active .nav-label {
-  color: #007AFF;
+  color: var(--apple-blue);
 }
 
 /* 工具类 */

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -220,7 +220,7 @@ onMounted(() => {
 }
 
 .page-header {
-  background: linear-gradient(135deg, #007AFF, #0056CC);
+  background: linear-gradient(135deg, var(--apple-blue), #0056CC);
   color: white;
   padding: 24px 20px;
   text-align: center;
@@ -261,7 +261,7 @@ onMounted(() => {
 }
 
 .action-card.primary {
-  background: linear-gradient(135deg, #007AFF, #0056CC);
+  background: linear-gradient(135deg, var(--apple-blue), #0056CC);
   color: white;
   border: none;
 }
@@ -283,7 +283,7 @@ onMounted(() => {
 }
 
 .action-card:not(.primary) .action-icon {
-  background: #007AFF;
+  background: var(--apple-blue);
   color: white;
 }
 
@@ -339,7 +339,7 @@ onMounted(() => {
 .stat-number {
   font-size: 24px;
   font-weight: 700;
-  color: #007AFF;
+  color: var(--apple-blue);
   margin-bottom: 4px;
 }
 
@@ -372,7 +372,7 @@ onMounted(() => {
 }
 
 .quick-item .el-icon {
-  color: #007AFF;
+  color: var(--apple-blue);
   margin-bottom: 8px;
 }
 
@@ -408,7 +408,7 @@ onMounted(() => {
   width: 40px;
   height: 40px;
   border-radius: 10px;
-  background: #007AFF;
+  background: var(--apple-blue);
   color: white;
   display: flex;
   align-items: center;

--- a/frontend/src/views/Maintenance.vue
+++ b/frontend/src/views/Maintenance.vue
@@ -429,7 +429,7 @@ onMounted(() => {
 }
 
 .page-header {
-  background: linear-gradient(135deg, #007AFF, #0056CC);
+  background: linear-gradient(135deg, var(--apple-blue), #0056CC);
   color: white;
   padding: 20px 16px;
 }
@@ -479,7 +479,7 @@ onMounted(() => {
 .vehicle-plate {
   font-size: 24px;
   font-weight: 700;
-  color: #007AFF;
+  color: var(--apple-blue);
   margin-bottom: 16px;
   text-align: center;
 }
@@ -529,7 +529,7 @@ onMounted(() => {
   display: block;
   font-size: 20px;
   font-weight: 700;
-  color: #007AFF;
+  color: var(--apple-blue);
   margin-bottom: 4px;
 }
 

--- a/frontend/src/views/Vehicles.vue
+++ b/frontend/src/views/Vehicles.vue
@@ -424,7 +424,7 @@ onMounted(() => {
 }
 
 .page-header {
-  background: linear-gradient(135deg, #007AFF, #0056CC);
+  background: linear-gradient(135deg, var(--apple-blue), #0056CC);
   color: white;
   padding: 20px 16px;
   display: flex;
@@ -515,7 +515,7 @@ onMounted(() => {
 .plate-number {
   font-size: 20px;
   font-weight: 700;
-  color: #007AFF;
+  color: var(--apple-blue);
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- introduce global CSS variables for Apple style colors and fonts
- update Element Plus components and views to use the new Apple theme
- replace hard-coded blue with `var(--apple-blue)` throughout

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` in `frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685821c0a15083239f68513363bead5b